### PR TITLE
Fix SpawnPrefabAsServerAndRemoveFromWorld crash

### DIFF
--- a/Don'tStarveTogether/modmain.lua
+++ b/Don'tStarveTogether/modmain.lua
@@ -27,3 +27,25 @@ end
 
 
 AddPrefabPostInit("cookpot", SmarterCookpotInit)
+
+AddSimPostInit(function()
+    -- Smarter Crock Pot & Advanced Tooltips mods compatibility hack
+    -- net_vars for mod component actions are not created when they spawn an item with TheWorld.mastersim forced to true - ModManager reads it and may return that no server mods are enabled
+    if not GLOBAL.TheNet:GetIsServer() then
+        local ModManager = GLOBAL.ModManager
+        if ModManager.old_mastersim_GetServerModsNames == nil then
+            ModManager.old_mastersim_GetServerModsNames = ModManager.GetServerModsNames
+            ModManager.GetServerModsNames = function(self)
+                -- replaced TheWorld.ismastersim with TheNet:GetIsServer()
+                if GLOBAL.TheNet:GetIsServer() then
+                    return self:GetEnabledServerModNames()
+                else
+                    if self.servermods == nil then
+                        self.servermods = GLOBAL.TheNet:GetServerModNames()
+                    end
+                    return self.servermods
+                end
+            end
+        end
+    end
+end)


### PR DESCRIPTION
Fixes a crash described in issue #4.

Full credit for this goes to Steam user Muche: http://steamcommunity.com/workshop/filedetails/discussion/365119238/520518688938428143/#c451850849196015775