### PR TITLE
Buttoninfo parameters and Warly's crockpot

### DIFF
--- a/Don'tStarveTogether/modmain.lua
+++ b/Don'tStarveTogether/modmain.lua
@@ -11,8 +11,6 @@ end
 
 
 local function SmarterCookpotInit(prefab)
-	
-    
 	prefab:AddTag("SMARTERCROCKPOT")
 	if not prefab.components.predicter then
         prefab:AddComponent("predicter")
@@ -27,3 +25,4 @@ end
 
 
 AddPrefabPostInit("cookpot", SmarterCookpotInit)
+AddPrefabPostInit("portablecookpot", SmarterCookpotInit)

--- a/Don'tStarveTogether/modmain_segments/containers_setup.lua
+++ b/Don'tStarveTogether/modmain_segments/containers_setup.lua
@@ -59,10 +59,10 @@ local function button_push_fn(inst,action)
         end
     end
 end
-function params.cookpot.widget.buttoninfo2.fn(inst)
+function params.cookpot.widget.buttoninfo2.fn(inst, doer)
     action = GLOBAL.ACTIONS.PREDICT
     if inst.components.container ~= nil then
-        GLOBAL.BufferedAction(inst.components.container.opener, inst, action):Do()
+        GLOBAL.BufferedAction(doer, inst, action):Do()
     elseif inst.replica.container ~= nil and not inst.replica.container:IsBusy() then
         -- if inst:HasTag("SMARTERCROCKPOT-NOTCLIENTONLY") then
             -- print("Requesting Prediction from server xxxx")
@@ -77,10 +77,10 @@ function params.cookpot.widget.buttoninfo2.fn(inst)
         -- end
     end
 end
-function params.cookpot.widget.buttoninfo.fn(inst)
+function params.cookpot.widget.buttoninfo.fn(inst, doer)
     action = GLOBAL.ACTIONS.COOK
     if inst.components.container ~= nil then
-        GLOBAL.BufferedAction(inst.components.container.opener, inst, action):Do()
+        GLOBAL.BufferedAction(doer, inst, action):Do()
     elseif inst.replica.container ~= nil and not inst.replica.container:IsBusy() then
         GLOBAL.SendRPCToServer(GLOBAL.RPC.DoWidgetButtonAction, action.code, inst,action.mod_name)
     end
@@ -91,6 +91,7 @@ function params.cookpot.widget.buttoninfo.validfn(inst)
 end
 params.cookpot.widget.buttoninfo2.validfn = params.cookpot.widget.buttoninfo.validfn 
 
+params.portablecookpot = params.cookpot
 
 containers.smartercrockpot_old_widgetsetup=containers.widgetsetup
 
@@ -98,6 +99,14 @@ function containers.widgetsetup(container, prefab,data)
     target = prefab or container.inst.prefab
     if target == "cookpot" then
         local t = params.cookpot
+        if t ~= nil then
+            for k, v in pairs(t) do
+                container[k] = v
+            end
+            container:SetNumSlots(container.widget.slotpos ~= nil and #container.widget.slotpos or 0)
+        end
+    elseif target == "portablecookpot" then
+        local t = params.portablecookpot
         if t ~= nil then
             for k, v in pairs(t) do
                 container[k] = v

--- a/Don'tStarveTogether/scripts/cooking_replica.lua
+++ b/Don'tStarveTogether/scripts/cooking_replica.lua
@@ -37,8 +37,7 @@ end
 
 
 function GetCandidateRecipes(cooker, ingdata)
-	
-	local recipes = cooking.recipes["cookpot"] or {}
+	local recipes = cooking.recipes[cooker] or {}
 	local candidates = {}
 
 	--find all potentially valid recipes
@@ -85,7 +84,7 @@ function PredictMany(prefab)
 	for k,v in pairs (slots) do
 		table.insert(ings, v.prefab)
 	end
-	local results=PredictRecipes(prefab,ings)
+	local results=PredictRecipes(prefab.prefab,ings)
 	return results
 end			
 


### PR DESCRIPTION
Updated the widget's buttoninfo function parameters (now it takes a `doer`): this fixes the issue that the "Cook!" button has no functionality

Added support for Warly's portable crockpot. This also means no more hardcoding cooker type